### PR TITLE
Installing GMP extension in local container

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,7 @@ For the floorplan to work, you need a mapbox token (see `.env`). Ask [@vdwijngae
 ### Push notifications
 The GMP PHP extension needs to be installed for the notifications, but it doesn't seem possible to do so by configuration yet using `wp-env`.
 
-It can be enabled like so (after first running `npm run wp-env start` of course):
-
-```bash
-#!/usr/bin/env bash
-
-# Get name of the wordpress container (not the test container)
-CONTAINER_NAME=$(docker ps -f name=-wordpress-1 -q | tail -n1 | xargs docker inspect | jq -r '.[0].Name')
-
-# Grab it manually from `docker ps -f name=-wordpress-1` if not working.
-
-# Install prereqs & configure gmp extension
-docker exec $CONTAINER_NAME apt-get update -y \
-	&& docker exec $CONTAINER_NAME apt-get install libgmp-dev \
-	&& docker exec $CONTAINER_NAME docker-php-ext-configure gmp \
-	&& docker restart $CONTAINER_NAME
-
-# Verify that the extension is installed:
-docker exec $CONTAINER_NAME php -i | grep gmp
-```
+It can be enabled with `npm run prepare-wp-env`. In case of issues, try and execute the steps in [`bin/install-gmp-extension.sh`](./bin/install-gmp-extension.sh) manually.
 
 ## Front-end
 This project was originally bootstrapped with [Create React App](https://github.com/facebook/create-react-app).

--- a/bin/install-gmp-extension.sh
+++ b/bin/install-gmp-extension.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Get name of the wordpress container (not the test container)
+CONTAINER_NAME=$(docker ps -f name=-wordpress -q | tail -n1 | xargs docker inspect | jq -r '.[0].Name')
+
+# Grab it manually from `docker ps -f name=-wordpress` if not working.
+
+# Install prereqs & gmp extension
+docker exec "$CONTAINER_NAME" apt-get update -y \
+	&& docker exec "$CONTAINER_NAME" apt-get -y install libgmp-dev \
+	&& docker exec "$CONTAINER_NAME" docker-php-ext-install gmp \
+	&& docker restart "$CONTAINER_NAME"
+
+# Verify that the extension is installed:
+docker exec "$CONTAINER_NAME" php -i | grep gmp

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "scripts": {
     "wp-env": "wp-env",
+    "prepare-wp-env": "./bin/install-gmp-extension.sh",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
This provides a script to automate installing GMP extension with an npm script, as it's reverted every time the wp-env is restarted.

See #16 