### PR TITLE
show speaker and bio in activity sidebar

### DIFF
--- a/src/components/Activities/ActivityCard.js
+++ b/src/components/Activities/ActivityCard.js
@@ -16,8 +16,8 @@ import {
 	trackWindowScroll,
 } from "react-lazy-load-image-component";
 import Period from "./Single/Period";
-import { connect } from "react-redux";
-import { getLocationByName, getPastActivities } from "../../redux/selectors";
+import {connect} from "react-redux";
+import {getLocationByName, getPastActivities, getPersonById} from "../../redux/selectors";
 import LikeButton from "../UI/LikeButton";
 import { toggleFavorite } from "../../redux/actions";
 import {prefixRoute} from "../../routing";
@@ -104,7 +104,7 @@ class ActivityCard extends React.Component {
 	);
 
 	render() {
-		const { classes, activity, scrollPosition, isPast, ...others } =
+		const {classes, activity, scrollPosition, isPast, persons, ...others} =
 			this.props;
 
 		let imageUrl = undefined;
@@ -112,8 +112,14 @@ class ActivityCard extends React.Component {
 		if (activity && activity.logo && activity.logo !== "") {
 			imageUrl = `https://pretalx.fri3d.be/${activity.logo}`;
 		} else {
-            imageUrl = defaultImage;
-        }
+			imageUrl = defaultImage;
+		}
+
+		let cardContent = activity.excerpt;
+
+		if (Array.isArray(persons) && persons.length > 0) {
+			cardContent += `<br><br><em>${persons.map(person => person.publicName).join(", ")}</em>`;
+		}
 
 		const activityCardContent = (
 			<ActivityCardContent
@@ -121,8 +127,8 @@ class ActivityCard extends React.Component {
 				activity={activity}
 				image={imageUrl}
 				title={activity.title}
-				subHeader={<this.SubHeader activity={activity} />}
-				content={activity.excerpt}
+				subHeader={<this.SubHeader activity={activity}/>}
+				content={cardContent}
 				{...others}
 			/>
 		);
@@ -190,6 +196,7 @@ const ActivityCardContent = ({
 const mapStateToProps = (state, { activity }) => {
 	const isFavorite = state.favoriteActivities.includes(activity.id);
 	const pastActivities = getPastActivities(state);
+	const persons = activity.persons.map(person => getPersonById(state)(person));
 
 	const isPast = pastActivities.indexOf(activity.id) !== -1;
 
@@ -197,6 +204,7 @@ const mapStateToProps = (state, { activity }) => {
 		location: getLocationByName(state)(activity.location),
 		isFavorite,
 		isPast,
+		persons,
 	};
 };
 

--- a/src/components/Activities/ActivityCard.js
+++ b/src/components/Activities/ActivityCard.js
@@ -196,7 +196,7 @@ const ActivityCardContent = ({
 const mapStateToProps = (state, { activity }) => {
 	const isFavorite = state.favoriteActivities.includes(activity.id);
 	const pastActivities = getPastActivities(state);
-	const persons = activity.persons.map(person => getPersonById(state)(person));
+	const persons = activity && activity.persons.map(person => getPersonById(state)(person)) || [];
 
 	const isPast = pastActivities.indexOf(activity.id) !== -1;
 

--- a/src/components/Activities/Single/Sidebar.js
+++ b/src/components/Activities/Single/Sidebar.js
@@ -51,9 +51,8 @@ const Sidebar = ({activity, location, day, persons}) => {
 					)}
 				</CardBlock>
 			</Grid>
-			{persons.length > 0 ? persons.map(person => (<Grid item xs={12} sm={6} md={12}>
+			{persons.length > 0 ? persons.map(person => (<Grid key={person.code} item xs={12} sm={6} md={12}>
 				<CardBlock
-					key={person.code}
 					header={{
 					title: person.publicName,
 					titleTypographyProps: {
@@ -88,7 +87,7 @@ const Sidebar = ({activity, location, day, persons}) => {
 
 const mapStateToProps = (state, { activity }) => {
 	const location = getLocationByName(state)(activity.location);
-	const persons = activity.persons.map(person => getPersonById(state)(person));
+	const persons = activity && activity.persons.map(person => getPersonById(state)(person)) || [];
 
 	return {
 		day: getDayById(state)(activity.day),

--- a/src/components/Activities/Single/Sidebar.js
+++ b/src/components/Activities/Single/Sidebar.js
@@ -1,13 +1,14 @@
 import React from "react";
-import { Avatar, CardActions, Grid } from "@material-ui/core";
+import {Avatar, CardActions, Grid, Typography} from "@material-ui/core";
 import moment from "moment";
 import Details from "./Details";
 import { AddToCalendar } from "../../UI/AddToCalendar";
 import CardBlock from "../../UI/CardBlock";
-import { connect } from "react-redux";
-import { getDayById, getLocationByName } from "../../../redux/selectors";
+import {connect} from "react-redux";
+import {getDayById, getLocationByName, getPersonById} from "../../../redux/selectors";
 import UpcomingActivities from "../UpcomingActivities";
 import {prefixRoute} from "../../../routing";
+import PersonIcon from "@material-ui/icons/Person";
 
 const getEvent = (activity) => {
 	const startDatetime = moment(activity.period.start).subtract(2, "hours");
@@ -27,7 +28,7 @@ const getEvent = (activity) => {
 	};
 };
 
-const Sidebar = ({ activity, location, day }) => {
+const Sidebar = ({activity, location, day, persons}) => {
 	if (activity === null) {
 		return null;
 	}
@@ -45,11 +46,28 @@ const Sidebar = ({ activity, location, day }) => {
 					/>
 					{event && (
 						<CardActions disableActionSpacing>
-							<AddToCalendar event={event} />
+							<AddToCalendar event={event}/>
 						</CardActions>
 					)}
 				</CardBlock>
 			</Grid>
+			{persons.length > 0 ? persons.map(person => (<Grid item xs={12} sm={6} md={12}>
+				<CardBlock
+					key={person.code}
+					header={{
+					title: person.publicName,
+					titleTypographyProps: {
+						variant: "h5",
+					},
+					avatar: <Avatar>
+						<PersonIcon />
+					</Avatar>,
+				}}>
+					<Typography
+						variant="body1"
+					>{person.biography || ''}</Typography>
+				</CardBlock>
+			</Grid>)) : null}
 			{activity.location !== "terrein" && (
 				<Grid item xs={12} sm={6} md={12}>
 					<CardBlock
@@ -57,7 +75,7 @@ const Sidebar = ({ activity, location, day }) => {
 						header={{
 							title: location.name,
 							subheader: location.subTitle,
-							avatar: <Avatar src={location.icon} />,
+							avatar: <Avatar src={location.icon}/>,
 						}}
 					>
 						<UpcomingActivities location={activity.location} />
@@ -70,10 +88,12 @@ const Sidebar = ({ activity, location, day }) => {
 
 const mapStateToProps = (state, { activity }) => {
 	const location = getLocationByName(state)(activity.location);
+	const persons = activity.persons.map(person => getPersonById(state)(person));
 
 	return {
 		day: getDayById(state)(activity.day),
 		location,
+		persons,
 	};
 };
 export default connect(mapStateToProps)(Sidebar);

--- a/src/containers/Activity.js
+++ b/src/containers/Activity.js
@@ -12,7 +12,7 @@ import CardBlock from "../components/UI/CardBlock";
 import FeatureList from "../components/Activities/Single/FeatureList";
 import Sidebar from "../components/Activities/Single/Sidebar";
 import LikeButton from "../components/UI/LikeButton";
-import { getActivityLoader } from "../redux/selectors";
+import {getActivityLoader, getPersonById} from "../redux/selectors";
 import ShareOptions from "../components/Activities/Single/ShareOptions";
 import defaultImage from "../img/default_image.png";
 
@@ -54,7 +54,7 @@ class Activity extends React.Component {
 	}
 
 	renderActivity = () => {
-		const { activity, toggleFavorite, isFavorite } = this.props;
+		const { activity, toggleFavorite, isFavorite, persons } = this.props;
 
 		if (!activity) {
 			return <LoadingIndicator />;
@@ -68,6 +68,8 @@ class Activity extends React.Component {
             imageUrl = defaultImage;
         }
 
+		let cardContent = `<p><em>${activity.excerpt}</em></p><p>${activity.content}</p>`;
+
 		return (
 			<Grid container spacing={24} style={{ position: "relative" }}>
 				<ShareOptions activity={activity} />
@@ -77,6 +79,7 @@ class Activity extends React.Component {
 						mediaProps={{ style: { paddingTop: "56.25%", backgroundSize: "cover" } }}
 						header={{
 							title: activity.title,
+							subheader: Array.isArray(persons) && persons.length > 0 ? persons.map(person => person.publicName).join(", ") : undefined,
 							titleTypographyProps: { variant: "h2" },
 						}}
 						raw={true}
@@ -85,7 +88,7 @@ class Activity extends React.Component {
 							active={isFavorite}
 							onClick={() => toggleFavorite(activity.id)}
 						/>
-						<DetailPane content={activity.content} />
+						<DetailPane content={cardContent} />
 						<FeatureList activity={activity} />
 					</CardBlock>
 				</Grid>
@@ -110,11 +113,13 @@ const mapStateToProps = (state, ownProps) => {
 	const activityLoader = getActivityLoader(state);
 	const activity = activities[activityId];
 	const needsPreloading = !activity && activityLoader.isFetching;
+	const persons = activity && activity.persons.map(person => getPersonById(state)(person)) || [];
 
 	return {
 		activity,
 		needsPreloading,
 		isFavorite,
+		persons,
 	};
 };
 

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -23,6 +23,7 @@ const initialState = {
 			return obj;
 		}, {}),*/
 		locations: {},
+		persons: {},
 	},
 	notifications: {
 		reply: null,

--- a/src/redux/selectors/index.js
+++ b/src/redux/selectors/index.js
@@ -7,6 +7,7 @@ const getActivityFilter = (state) => state.activityFilter.filter;
 
 const getCurrentDate = (state) => state.general.currentDate;
 const getLocations = (state) => state.entities.locations;
+const getPersons = (state) => state.entities.persons;
 const getDays = (state) => state.entities.days;
 const getFavoriteActivityIds = (state) => state.favoriteActivities;
 
@@ -164,6 +165,11 @@ export const getLocationByName = createSelector(
 	(locations) => (location) => {
 		return locations[location];
 	}
+);
+
+export const getPersonById = createSelector(
+	[getPersons],
+	(persons) => (person) => persons[person]
 );
 
 export const getActivitiesByLocation = createSelector(


### PR DESCRIPTION
Implements #29. 

Changed:

* Lists speakers and their bio in single activity sidebar
* Adds speakers as subheader for single activity view
* Adds excerpt before content in single activity
* Adds speakers below excerpt in activity collapsible content


![image](https://user-images.githubusercontent.com/772137/183284659-dc37c7d7-a5ee-4224-bead-76e04b2fba44.png)
![image](https://user-images.githubusercontent.com/772137/183284674-00801b9b-a4f5-4b9f-8739-c4e5b7d3877c.png)
